### PR TITLE
Added the missing make:filament-action command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Kickstart your project and save time with Larament! This time-saving starter kit
 - All component labels are automatically translatable.
 - A `composer review` command that runs PINT, PHPStan, and PEST.
 - Helper file is included for custom helper functions.
+- A custom `php artisan make:filament-action` command is available for creating actions.
 
 ### Design
 ![user-global-search](https://raw.githubusercontent.com/CodeWithDennis/larament/main/resources/images/user-global-search.jpg)

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -14,6 +14,7 @@ use function Laravel\Prompts\warning;
 class MakeFilamentActionCommand extends Command
 {
     protected $signature = 'make:filament-action {name?}';
+
     protected $description = 'Create a new Filament action class';
 
     /**
@@ -27,6 +28,7 @@ class MakeFilamentActionCommand extends Command
 
         if ($this->fileExists($path)) {
             warning("$className already exists.");
+
             return;
         }
 
@@ -49,7 +51,7 @@ class MakeFilamentActionCommand extends Command
 
     private function getClassName(string $name): string
     {
-        return Str::studly($name) . 'Action';
+        return Str::studly($name).'Action';
     }
 
     private function getFilePath(string $className): string
@@ -68,6 +70,7 @@ class MakeFilamentActionCommand extends Command
     private function getStubContent(): string
     {
         $stubPath = app_path('Filament/Actions/Stubs/FilamentAction.stub');
+
         return File::get($stubPath);
     }
 

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 
 use function Laravel\Prompts\info;
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\warning;
 
@@ -25,8 +26,6 @@ class MakeFilamentActionCommand extends Command
     protected $description = 'Create a new Filament action class';
 
     /**
-     * Mapping of type flags to their corresponding action class.
-     *
      * @var array<string, string>
      */
     protected array $actionTypes = [
@@ -96,11 +95,23 @@ class MakeFilamentActionCommand extends Command
         }
 
         if (count($selectedTypes) === 0) {
-            warning('No action type specified. Please provide one.');
-            exit;
+            $selectedType = select(
+                label: 'What type of action is this for?',
+                options: [
+                    'form' => 'Form component action',
+                    'table' => 'Table component action',
+                    'table-bulk' => 'Table bulk action',
+                    'infolist' => 'Infolist component action',
+                    'notification' => 'Notification action',
+                    'global-search' => 'Global search result action',
+                    'custom-component' => 'Custom Component',
+                ]
+            );
+
+            return (string) $selectedType;
         }
 
-        return key($selectedTypes);
+        return (string) key($selectedTypes);
     }
 
     private function getFilePath(string $className, string $type): string

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -73,7 +73,9 @@ class MakeFilamentActionCommand extends Command
 
     private function getClassName(string $name): string
     {
-        return Str::endsWith($name, 'Action') ? Str::studly($name) : Str::studly($name).'Action';
+        return Str::endsWith(Str::lower($name), 'action')
+            ? Str::studly($name)
+            : Str::studly($name).'Action';
     }
 
     private function getActionType(): string

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -77,7 +77,7 @@ class MakeFilamentActionCommand extends Command
     private function generateActionFile(string $path, string $className, string $stubContent): void
     {
         $namespace = 'App\\Filament\\Actions';
-        $defaultName = Str::snake(Str::replaceLast('Action', '', $className));
+        $defaultName = Str::camel(Str::replaceLast('Action', '', $className));
 
         $content = str_replace(
             ['{{ namespace }}', '{{ className }}', '{{ defaultName }}'],

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -38,9 +38,6 @@ class MakeFilamentActionCommand extends Command
         'global-search' => 'Filament\\GlobalSearch\\Actions\\Action',
     ];
 
-    /**
-     * @throws FileNotFoundException
-     */
     public function handle(): void
     {
         $name = $this->getNameArgument();

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -47,7 +47,7 @@ class MakeFilamentActionCommand extends Command
         $className = $this->getClassName($name);
         $type = $this->getActionType();
         $actionClass = $this->actionTypes[$type];
-        $baseClass = $type === 'table-bulk' ? 'BulkAction' : 'Action';  // Determine base class
+        $baseClass = $type === 'table-bulk' ? 'BulkAction' : 'Action';
         $path = $this->getFilePath($className, $type);
 
         if ($this->fileExists($path)) {

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -94,7 +94,7 @@ class MakeFilamentActionCommand extends Command
 
         if (count($selectedTypes) === 0) {
             $selectedType = select(
-                label: 'What type of action is this for?',
+                label: 'Please select the type you require.',
                 options: [
                     'form' => 'Form component action',
                     'table' => 'Table component action',

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -92,6 +92,7 @@ class MakeFilamentActionCommand extends Command
 
         if (count($selectedTypes) > 1) {
             warning('Please specify only one action type.');
+
             exit;
         }
 
@@ -135,9 +136,6 @@ class MakeFilamentActionCommand extends Command
         return File::exists($path);
     }
 
-    /**
-     * @throws FileNotFoundException
-     */
     private function getStubContent(): string
     {
         $stubPath = app_path('Filament/Actions/Stubs/FilamentAction.stub');
@@ -163,8 +161,7 @@ class MakeFilamentActionCommand extends Command
     private function getNamespace(string $path): string
     {
         $relativePath = Str::after($path, app_path().'/');
-        $namespace = Str::replace('/', '\\', dirname($relativePath));
 
-        return 'App\\'.$namespace;
+        return 'App\\'.Str::replace('/', '\\', dirname($relativePath));
     }
 }

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -98,15 +98,15 @@ class MakeFilamentActionCommand extends Command
 
         if (count($selectedTypes) === 0) {
             $selectedType = select(
-                label: 'Please select the type you require.',
+                label: 'Please select the type of the Filament Action',
                 options: [
-                    'form' => 'Form component action',
-                    'table' => 'Table component action',
-                    'table-bulk' => 'Table bulk action',
-                    'infolist' => 'Infolist component action',
-                    'notification' => 'Notification action',
-                    'global-search' => 'Global search result action',
-                    'custom-component' => 'Custom Component',
+                    'form' => 'Form',
+                    'table' => 'Table',
+                    'table-bulk' => 'TableBulk',
+                    'infolist' => 'Infolist',
+                    'notification' => 'Notification',
+                    'global-search' => 'GlobalSearch',
+                    'custom-component' => 'Custom',
                 ]
             );
 

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\warning;
+
+class MakeFilamentActionCommand extends Command
+{
+    protected $signature = 'make:filament-action {name?}';
+    protected $description = 'Create a new Filament action class';
+
+    /**
+     * @throws FileNotFoundException
+     */
+    public function handle(): void
+    {
+        $name = $this->getNameArgument();
+        $className = $this->getClassName($name);
+        $path = $this->getFilePath($className);
+
+        if ($this->fileExists($path)) {
+            warning("$className already exists.");
+            return;
+        }
+
+        $stubContent = $this->getStubContent();
+        $this->generateActionFile($path, $className, $stubContent);
+
+        info("$className created successfully at:");
+        info($path);
+    }
+
+    private function getNameArgument(): string
+    {
+        return $this->argument('name') ?? text(
+            label: 'Enter the name of the Filament Action',
+            placeholder: 'MyActionName',
+            required: 'Action name is required.',
+            hint: "We will append 'Action' to this name, so no need to include it."
+        );
+    }
+
+    private function getClassName(string $name): string
+    {
+        return Str::studly($name) . 'Action';
+    }
+
+    private function getFilePath(string $className): string
+    {
+        return app_path("Filament/Actions/$className.php");
+    }
+
+    private function fileExists(string $path): bool
+    {
+        return File::exists($path);
+    }
+
+    /**
+     * @throws FileNotFoundException
+     */
+    private function getStubContent(): string
+    {
+        $stubPath = app_path('Filament/Actions/Stubs/FilamentAction.stub');
+        return File::get($stubPath);
+    }
+
+    private function generateActionFile(string $path, string $className, string $stubContent): void
+    {
+        $namespace = 'App\\Filament\\Actions';
+        $defaultName = Str::snake(Str::replaceLast('Action', '', $className));
+
+        $content = str_replace(
+            ['{{ namespace }}', '{{ className }}', '{{ defaultName }}'],
+            [$namespace, $className, $defaultName],
+            $stubContent
+        );
+
+        File::ensureDirectoryExists(app_path('Filament/Actions'));
+        File::put($path, $content);
+    }
+}

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -66,15 +66,13 @@ class MakeFilamentActionCommand extends Command
     {
         return $this->argument('name') ?? text(
             label: 'Enter the name of the Filament Action',
-            placeholder: 'MyActionName',
             required: 'Action name is required.',
-            hint: "We will append 'Action' to this name, so no need to include it."
         );
     }
 
     private function getClassName(string $name): string
     {
-        return Str::studly($name).'Action';
+        return Str::endsWith($name, 'Action') ? Str::studly($name) : Str::studly($name) . 'Action';
     }
 
     private function getActionType(): string

--- a/app/Console/Commands/MakeFilamentActionCommand.php
+++ b/app/Console/Commands/MakeFilamentActionCommand.php
@@ -47,6 +47,7 @@ class MakeFilamentActionCommand extends Command
         $className = $this->getClassName($name);
         $type = $this->getActionType();
         $actionClass = $this->actionTypes[$type];
+        $baseClass = $type === 'table-bulk' ? 'BulkAction' : 'Action';  // Determine base class
         $path = $this->getFilePath($className, $type);
 
         if ($this->fileExists($path)) {
@@ -56,7 +57,7 @@ class MakeFilamentActionCommand extends Command
         }
 
         $stubContent = $this->getStubContent();
-        $this->generateActionFile($path, $className, $actionClass, $stubContent);
+        $this->generateActionFile($path, $className, $actionClass, $stubContent, $baseClass);
 
         info("$className created successfully at:");
         info($path);
@@ -72,7 +73,7 @@ class MakeFilamentActionCommand extends Command
 
     private function getClassName(string $name): string
     {
-        return Str::endsWith($name, 'Action') ? Str::studly($name) : Str::studly($name) . 'Action';
+        return Str::endsWith($name, 'Action') ? Str::studly($name) : Str::studly($name).'Action';
     }
 
     private function getActionType(): string
@@ -142,14 +143,14 @@ class MakeFilamentActionCommand extends Command
         return File::get($stubPath);
     }
 
-    private function generateActionFile(string $path, string $className, string $actionClass, string $stubContent): void
+    private function generateActionFile(string $path, string $className, string $actionClass, string $stubContent, string $baseClass): void
     {
         $namespace = $this->getNamespace($path);
         $defaultName = Str::camel(Str::replaceLast('Action', '', $className));
 
         $content = str_replace(
-            ['{{ namespace }}', '{{ className }}', '{{ defaultName }}', '{{ actionClass }}'],
-            [$namespace, $className, $defaultName, $actionClass],
+            ['{{ namespace }}', '{{ className }}', '{{ defaultName }}', '{{ actionClass }}', '{{ baseClass }}'],
+            [$namespace, $className, $defaultName, $actionClass, $baseClass],
             $stubContent
         );
 

--- a/app/Filament/Actions/GlobalSearch/TestAction.php
+++ b/app/Filament/Actions/GlobalSearch/TestAction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Actions\GlobalSearch;
+
+use Filament\GlobalSearch\Actions\Action;
+
+class TestAction extends Action
+{
+    public static function getDefaultName(): ?string
+    {
+        return 'test';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // TODO: Add your setup logic here
+    }
+}

--- a/app/Filament/Actions/Stubs/FilamentAction.stub
+++ b/app/Filament/Actions/Stubs/FilamentAction.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use Filament\Forms\Components\Actions\Action;
+use {{ actionClass }};
 
 class {{ className }} extends Action
 {

--- a/app/Filament/Actions/Stubs/FilamentAction.stub
+++ b/app/Filament/Actions/Stubs/FilamentAction.stub
@@ -3,9 +3,6 @@
 namespace {{ namespace }};
 
 use Filament\Forms\Components\Actions\Action;
-use Filament\Forms\Set;
-use Filament\Notifications\Notification;
-use Illuminate\Support\Str;
 
 class {{ className }} extends Action
 {

--- a/app/Filament/Actions/Stubs/FilamentAction.stub
+++ b/app/Filament/Actions/Stubs/FilamentAction.stub
@@ -4,7 +4,7 @@ namespace {{ namespace }};
 
 use {{ actionClass }};
 
-class {{ className }} extends Action
+class {{ className }} extends {{ baseClass }}
 {
     public static function getDefaultName(): ?string
     {

--- a/app/Filament/Actions/Stubs/FilamentAction.stub
+++ b/app/Filament/Actions/Stubs/FilamentAction.stub
@@ -1,0 +1,23 @@
+<?php
+
+namespace {{ namespace }};
+
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Set;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Str;
+
+class {{ className }} extends Action
+{
+    public static function getDefaultName(): ?string
+    {
+        return '{{ defaultName }}';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // TODO: Add your setup logic here
+    }
+}


### PR DESCRIPTION
I'm a big fan of action classes in general, I particularly love how you extracted Filament Actions.

This PR adds the missing `php artisan make:filament-action` command, allowing users to generate Filament action classes from the terminal.