### PR TITLE
Shorten herd command usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ function larament() {
       local project_name="$1"
       composer create-project --prefer-dist CodeWithDennis/larament "$project_name" || return 1
       cd "$project_name" || return 1
-      herd link && herd secure && herd open
+      herd link --secure && herd open
       ;;
     *)
       return 1


### PR DESCRIPTION
Replaces separate 'herd link' and 'herd secure' commands with a single 'herd link --secure' for improved clarity and accuracy in the advanced function example.