### PR TITLE
feat: Add translatable components support

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use Filament\Forms\Components\Field;
+use Filament\Forms\Components\Placeholder;
+use Filament\Infolists\Components\Entry;
+use Filament\Support\Components\Component;
+use Filament\Support\Concerns\Configurable;
+use Filament\Tables\Columns\Column;
+use Filament\Tables\Filters\BaseFilter;
 use Filament\Tables\Table;
 use Illuminate\Support\ServiceProvider;
 
@@ -17,6 +24,18 @@ final class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureTable();
+        $this->translatableComponents();
+    }
+
+    private function translatableComponents(): void
+    {
+        foreach ([Field::class, BaseFilter::class, Placeholder::class, Column::class, Entry::class] as $component) {
+            /* @var Configurable $component */
+            $component::configureUsing(function (Component $translatable): void {
+                /** @phpstan-ignore method.notFound */
+                $translatable->translateLabel();
+            });
+        }
     }
 
     private function configureTable(): void


### PR DESCRIPTION
This pull request introduces a new method to the `AppServiceProvider` to automatically enable label translation for several Filament UI components. The goal is to ensure that labels for fields, filters, placeholders, columns, and entries are translated consistently throughout the application.

Enhancements for translatable UI components:

* Added a `translatableComponents` method to `AppServiceProvider` that configures Filament components (`Field`, `BaseFilter`, `Placeholder`, `Column`, `Entry`) to automatically translate their labels by calling `translateLabel()` during configuration.
* Registered the new `translatableComponents` method in the `boot` lifecycle of the service provider to ensure the translation logic is applied at application startup.

Dependency and import updates:

* Added necessary `use` statements for Filament component classes and traits at the top of `AppServiceProvider.php` to support the new translation configuration.