### PR TITLE
Improve Plumb package score

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,5 +7,27 @@
 *.php diff=php
 
 /.github export-ignore
+/.cursor export-ignore
+/.DS_Store export-ignore
+/.env export-ignore
+/AGENTS.md export-ignore
+/boost.json export-ignore
+/cleanup.php export-ignore
+/bootstrap/cache/*.php export-ignore
+/database/database.sqlite export-ignore
+/node_modules export-ignore
+/phpunit.xml export-ignore
+/phpstan.neon export-ignore
+/pint.json export-ignore
+/public/build export-ignore
+/public/hot export-ignore
+/public/storage export-ignore
+/rector.php export-ignore
+/storage/debugbar export-ignore
+/storage/framework/views/* export-ignore
+/storage/logs/*.log export-ignore
+/storage/pail export-ignore
+/tests export-ignore
+/vendor export-ignore
 CHANGELOG.md export-ignore
 .styleci.yml export-ignore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pest.yml
+++ b/.github/workflows/pest.yml
@@ -18,16 +18,16 @@ jobs:
           mysql --host 127.0.0.1 -uroot -proot -e "SELECT @@global.secure_file_priv, @@global.local_infile"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
           coverage: none
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -7,16 +7,16 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2
         with:
           php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # v3
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan analyse --error-format=github --debug

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@b604ade2a87db23f8871b7182e69ec5e75effb45 # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: json, dom, curl, libxml, mbstring
@@ -28,6 +28,6 @@ jobs:
         run: pint
 
       - name: Commit linted files
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
         with:
           commit_message: "Fixes coding style"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![PHPStan](https://github.com/CodeWithDennis/larament/actions/workflows/phpstan.yml/badge.svg)](https://github.com/CodeWithDennis/larament/actions/workflows/phpstan.yml)
 [![Total Installs](https://img.shields.io/packagist/dt/codewithdennis/larament.svg?style=flat-square)](https://packagist.org/packages/codewithdennis/larament)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/codewithdennis/larament.svg?style=flat-square)](https://packagist.org/packages/codewithdennis/larament)
+[![Plumb score](https://plumbphp.dev/badges/codewithdennis/larament/composite.svg)](https://plumbphp.dev/codewithdennis/larament)
 
 <img width="1920" height="1080" alt="larament-banner-variant-b-github" src="https://github.com/user-attachments/assets/f90db4da-dcdd-46a8-ad5b-8709213f7a89" />
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities through GitHub private vulnerability reporting for this repository.
+
+Do not open a public issue for security reports. Include the affected version, reproduction steps, expected impact, and any suggested mitigation so the report can be triaged quickly.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "laravel/tinker": "^3.0",
         "nunomaduro/essentials": "^1.2",
         "psy/psysh": "^0.12.19",
-        "symfony/process": "^7.4"
+        "symfony/process": "^7.4.5 || ^8.0.5"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
@@ -25,7 +25,7 @@
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
         "pestphp/pest": "^v4.3.0",
-        "pestphp/pest-plugin-browser": "v4.0.3",
+        "pestphp/pest-plugin-browser": "^4.3.1",
         "pestphp/pest-plugin-faker": "^v4.0.0",
         "pestphp/pest-plugin-laravel": "^v4.0.0",
         "pestphp/pest-plugin-livewire": "^v4.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48e224bd1464161096dbf7754409556a",
+    "content-hash": "b93e903e9e92d4b080889abd812c398f",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -1545,22 +1545,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.13.1",
+            "version": "7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d"
+                "reference": "aef242412e13128b5049864867bb49fc37dd39de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/55901a76dfd2006a0cc012b9e3c5b487f796478d",
-                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aef242412e13128b5049864867bb49fc37dd39de",
+                "reference": "aef242412e13128b5049864867bb49fc37dd39de",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12.3",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.12.4",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -1572,7 +1572,7 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
                 "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
@@ -1653,7 +1653,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.13.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.14.0"
             },
             "funding": [
                 {
@@ -1669,20 +1669,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-29T20:14:18+00:00"
+            "time": "2026-07-08T22:54:09+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
@@ -1737,7 +1737,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -1753,20 +1753,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.3",
+            "version": "2.12.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
+                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
-                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
+                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
                 "shasum": ""
             },
             "require": {
@@ -1856,7 +1856,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.4"
             },
             "funding": [
                 {
@@ -1872,7 +1872,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-23T15:21:08+00:00"
+            "time": "2026-07-08T15:56:20+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -11197,37 +11197,37 @@
         },
         {
             "name": "pestphp/pest-plugin-browser",
-            "version": "v4.0.3",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-browser.git",
-                "reference": "7975507757d3fde0219afb80037b6a07b3df0d22"
+                "reference": "b6e76d3e4a2f81da9f050ec54be2a29b402287c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-browser/zipball/7975507757d3fde0219afb80037b6a07b3df0d22",
-                "reference": "7975507757d3fde0219afb80037b6a07b3df0d22",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-browser/zipball/b6e76d3e4a2f81da9f050ec54be2a29b402287c4",
+                "reference": "b6e76d3e4a2f81da9f050ec54be2a29b402287c4",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^3.1.1",
-                "amphp/http-server": "^3.4.3",
+                "amphp/http-server": "^3.4.4",
                 "amphp/websocket-client": "^2.0.2",
                 "ext-sockets": "*",
-                "pestphp/pest": "^4.0.4",
+                "pestphp/pest": "^4.4.5",
                 "pestphp/pest-plugin": "^4.0.0",
                 "php": "^8.3",
-                "symfony/process": "^7.3.3"
+                "symfony/process": "^7.4.8|^8.0.5"
             },
             "require-dev": {
                 "ext-pcntl": "*",
                 "ext-posix": "*",
-                "livewire/livewire": "^3.6.4",
-                "nunomaduro/collision": "^8.8.2",
-                "orchestra/testbench": "^10.6.0",
-                "pestphp/pest-dev-tools": "^4.0.0",
-                "pestphp/pest-plugin-laravel": "^4.0",
-                "pestphp/pest-plugin-type-coverage": "^4.0.2"
+                "livewire/livewire": "^3.7.15",
+                "nunomaduro/collision": "^8.9.3",
+                "orchestra/testbench": "^10.11.0",
+                "pestphp/pest-dev-tools": "^4.1.0",
+                "pestphp/pest-plugin-laravel": "^4.1",
+                "pestphp/pest-plugin-type-coverage": "^4.0.4"
             },
             "type": "library",
             "extra": {
@@ -11260,7 +11260,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-browser/tree/v4.0.3"
+                "source": "https://github.com/pestphp/pest-plugin-browser/tree/v4.3.1"
             },
             "funding": [
                 {
@@ -11276,7 +11276,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-08-31T19:14:52+00:00"
+            "time": "2026-04-08T21:04:12+00:00"
         },
         {
             "name": "pestphp/pest-plugin-faker",

--- a/tests/Browser/Filament/Auth/LoginTest.php
+++ b/tests/Browser/Filament/Auth/LoginTest.php
@@ -15,8 +15,8 @@ beforeEach(function () {
 
 test('an unauthenticated user can login', function () {
     visit('/admin/login')
-        ->fill('form.email', $this->user->email)
-        ->fill('form.password', 'password')
+        ->fill('input[id="form.email"]', $this->user->email)
+        ->fill('input[id="form.password"]', 'password')
         ->submit()
         ->assertSee('Dashboard');
 

--- a/tests/Browser/Filament/Resources/UserResourceTest.php
+++ b/tests/Browser/Filament/Resources/UserResourceTest.php
@@ -13,9 +13,9 @@ it('can create a new user', function () {
     visit('/admin')
         ->click('Users')
         ->click('New user')
-        ->fill('form.name', $user->name)
-        ->fill('form.email', $user->email)
-        ->fill('form.password', 'password')
+        ->fill('input[id="form.name"]', $user->name)
+        ->fill('input[id="form.email"]', $user->email)
+        ->fill('input[id="form.password"]', 'password')
         ->press('.fi-ac-btn-action[type=submit]')
         ->assertSee('Created');
 
@@ -31,7 +31,7 @@ it('can edit an existing user', function () {
     visit('/admin')
         ->click('Users')
         ->click('Edit')
-        ->fill('form.name', $newRecord->name)
+        ->fill('input[id="form.name"]', $newRecord->name)
         ->click('.fi-ac-btn-action[type=submit]')
         ->assertSee('Saved');
 


### PR DESCRIPTION
## Summary

This PR addresses the negative Plumb findings for `codewithdennis/larament` by tightening supply-chain security, adding repository security metadata, improving dependency automation, and cleaning the published Composer archive.

The current Plumb report showed the main score impact in the Security category, with additional lower-impact findings in package archive hygiene and Symfony ecosystem compatibility. This PR focuses on mechanically verifiable changes that Plumb can detect on the next release scan.

## What changed

- Pinned all third-party GitHub Actions to full commit SHAs while keeping comments with the original tag for maintainability.
- Added `.github/dependabot.yml` with Composer, npm, and GitHub Actions enabled, plus a 7-day cooldown for version updates.
- Added `SECURITY.md` that directs vulnerability reports to GitHub private vulnerability reporting instead of public issues.
- Expanded `.gitattributes` `export-ignore` rules so release archives exclude CI files, local/dev tooling, generated cache/log files, test files, vendored dependencies, `node_modules`, local database files, and private environment files.
- Relaxed the root `symfony/process` constraint to `^7.4.5 || ^8.0.5` so the package can resolve with the current Symfony line.
- Upgraded `pestphp/pest-plugin-browser` to `^4.3.1`, which supports Symfony Process 8.
- Updated vulnerable Guzzle transitive dependencies through the lockfile.
- Updated browser tests to use explicit Filament input selectors after the Pest browser plugin upgrade.

## Why

Plumb reported negative impact from:

- GitHub Actions referenced by mutable tags instead of immutable SHAs.
- No dependency updater configuration.
- No dependency update cooldown.
- No security disclosure policy.
- Dev/tooling files being shipped in the dist archive.
- `symfony/process` being constrained to Symfony 7 only.

These changes should improve the next Plumb scan after this branch is merged and a new package release is tagged.

## Verification

- `vendor/bin/pint --dirty --format agent`
- `composer validate --strict --no-check-publish`
- `composer audit --format=plain`
- `php artisan test --compact`
- `composer archive --format=zip --dir=/tmp --file=larament-dist-check --no-interaction`
- Parsed `.github/dependabot.yml` locally to verify YAML syntax.

Test result: `42 passed`, `133 assertions`.

Composer audit result: no security vulnerability advisories found.

## Notes

The Composer archive still keeps Laravel directory placeholder files such as `.gitignore` files under `storage/`, which are needed to preserve the expected starter-kit directory structure. Generated cache/log files and other local artifacts are excluded.
