### PR TITLE
fix: include cleanup.php in Composer dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,6 @@
 /.env export-ignore
 /AGENTS.md export-ignore
 /boost.json export-ignore
-/cleanup.php export-ignore
 /bootstrap/cache/*.php export-ignore
 /database/database.sqlite export-ignore
 /node_modules export-ignore


### PR DESCRIPTION
## Summary

`composer create-project` fails during `post-create-project-cmd` with:

```text
Could not open input file: cleanup.php
```

Composer installs the Packagist/GitHub **dist** zip, and `.gitattributes` currently marks `cleanup.php` as `export-ignore`, so the file is missing from the archive while `composer.json` still runs `@php cleanup.php`.

## Key changes

- Remove `/cleanup.php export-ignore` from `.gitattributes` so `cleanup.php` is included in release/dist archives.
- The script still deletes itself after a successful create-project run, so end-user projects stay clean.

## Behavior / impact

- New `composer create-project codewithdennis/larament ...` installs no longer fail on the cleanup step.
- Source checkouts are unchanged; only dist packaging is fixed.

## Test plan

- [ ] Confirm `.gitattributes` no longer lists `/cleanup.php export-ignore`.
- [ ] After the next release/tag, run `composer create-project codewithdennis/larament test-app` and verify `post-create-project-cmd` completes without the cleanup.php error.
- [ ] Verify `cleanup.php` is present in the dist zip before the script runs, and removed afterward by the script itself.