### PR TITLE
Refactor sidebar class names in theme.css

### DIFF
--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -3,10 +3,10 @@
 @source '../../../../app/Filament/**/*';
 @source '../../../../resources/views/filament/**/*';
 
-.fi-sidebar-nav {
+.fi-sidebar {
     border-right: 1px solid #e4e4e5;
 }
 
-.dark .fi-sidebar-nav {
-    border-right: 1px solid  #18181B;
+.dark .fi-sidebar {
+    border-right: 1px solid #18181B;
 }


### PR DESCRIPTION
fixes #155

## No Tenancy

<img width="2251" height="1336" alt="Screenshot 2026-08-14 at 23-21-15 Dashboard - Larament" src="https://github.com/user-attachments/assets/87304065-ed77-4fe9-a870-f3979178992a" />

## Tenancy

<img width="2251" height="1336" alt="Screenshot 2026-08-14 at 23-32-01 Dashboard - Larament" src="https://github.com/user-attachments/assets/ad29b794-6f1a-4ef0-a372-0b44d8f6c229" />

<img width="2251" height="1336" alt="Screenshot 2026-08-14 at 23-37-20 Dashboard - Larament" src="https://github.com/user-attachments/assets/81b8ff01-8b90-44bc-9d4f-cc3beb693f33" />



@CodeWithDennis let me know if you need the rebased onto another branch instead of `7.x` 